### PR TITLE
Restructures heading outline for the badging page

### DIFF
--- a/badging.html
+++ b/badging.html
@@ -4,10 +4,10 @@
     <meta charset="utf-8">
     <title>Event Badging Standard v2023-01 by The Public Health Pledge</title>
     <link rel="shortcut icon" href="img/favicon.png" type="image/png">
-    <link rel="stylesheet" href="main.css" type="text/css">
     <link rel="stylesheet" href="third_party/bootstrap/css/bootstrap.min.css">
     <link rel="stylesheet" href="third_party/fontawesome/css/all.min.css">
     <link rel="stylesheet" href="third_party/material-symbols/index.css">
+    <link rel="stylesheet" href="main.css" type="text/css">
     <meta property="og:image" content="img/icon.png">
     <meta property="og:description" content="The Public Health Pledge event badging standard can be used to quickly convey info about Health and Safety protocols, to help prospective participants assess risk.">
     <meta property="og:title" content="Event Badging Standard by The Public Health Pledge">
@@ -38,7 +38,7 @@
 
     <main class="container">
         <h1 class="sr-only">The Public Health Pledge Event Badging Standard</h1>
-        <p class="lead">Event Badging Standard, version 2023-01</p>
+        <h2 class="lead">Event Badging Standard, version 2023-01</h2>
 
         <p>The Public Health Pledge’s event badges are intended to quickly convey information about the Health and Safety protocols an event has in place, to help prospective participants assess risk. They are based on self-assessments the event organizers submit to the PHPledge team.</p>
 
@@ -56,80 +56,81 @@
 
         <p>There are logistical and financial challenges involved in meeting the “Robust Policy” grade, so event organizers who are doing their best may still find a mix of grades. “Efforts Made” and “No Policy” grades are opportunities for attendees to make themselves aware of areas of potential risk, and to assess for themselves how they handle that risk. As an organizer, this is an opportunity for you to communicate the efforts you have made in this area, to help your attendees understand how your event fits their risk profile.</p>
         
-        <div class="card" id="the-pledge">
+        <h2 class="sr-only">Different grading categories</h2>
+        <section class="card the-pledge" id="mask-grading-criteria" aria-labelledby="mask-grading-criteria-heading">
             <div class="card-body">
                 <span class="material-symbols-sharp floating-badge-icon" aria-hidden="true">masks</span>
                 <span class="sr-only">Mask icon</span>
-
-                <p><strong>Masks</strong> grading criteria:</p>
-
+                <h3 id="mask-grading-criteria-heading" class="card-title">
+                    <strong>Masks</strong> grading criteria:
+                </h3>
                 <ul>
                     <li>Robust Policy: Masks mandatory indoors and when in outdoor spaces where physical distancing cannot be maintained, except for presenters on stage, or attendees who are actively eating or drinking, with enforcement mechanism.</li>
                     <li>Efforts Made: Masks are made available and strongly recommended.</li>
                     <li>No Policy: No mention of masks.</li>
                 </ul>
             </div>
-        </div>
+        </section>
         
-        <div class="card" id="the-pledge">
+        <section class="card the-pledge" id="vaccine-grading-criteria" aria-labelledby="vaccine-grading-criteria-heading">
             <div class="card-body">
                 <span class="material-symbols-sharp floating-badge-icon" aria-hidden="true">vaccines</span>
                 <span class="sr-only">Vaccine icon</span>
-
-                <p><strong>Vaccines</strong> grading criteria:</p>
-
+                <h3 id="vaccine-grading-criteria-heading" class="card-title">
+                    <strong>Vaccines</strong> grading criteria:
+                </h3>
                 <ul>
                     <li>Robust Policy: Vaccines mandatory with appropriate exemptions, and a verification mechanism.</li>
                     <li>Efforts Made: Vaccines strongly recommended.</li>
                     <li>No Policy: No mention of vaccines.</li>
                 </ul>
             </div>
-        </div>
+        </section>
         
-        <div class="card" id="the-pledge">
+        <section class="card the-pledge" id="tests-grading-criteria" aria-labelledby="tests-grading-criteria-heading">
             <div class="card-body">
                 <span class="material-symbols-sharp floating-badge-icon" aria-hidden="true">labs</span>
                 <span class="sr-only">Test tube icon</span>
-
-                <p><strong>Tests</strong> grading criteria:</p>
-
+                <h3 id="tests-grading-criteria-heading" class="card-title">
+                    <strong>Tests</strong> grading criteria:
+                </h3>
                 <ul>
                     <li>Robust Policy: Daily negative test result required with a verification mechanism.</li>
                     <li>Efforts Made: Tests are made available and strongly recommended.</li>
                     <li>No Policy: No mention of tests.</li>
                 </ul>
             </div>
-        </div>
+        </section>
         
-        <div class="card" id="the-pledge">
+        <section class="card the-pledge" id="ventilation-grading-criteria" aria-labelledby="ventilation-grading-criteria-heading">
             <div class="card-body">
                 <span class="material-symbols-sharp floating-badge-icon" aria-hidden="true">air</span>
                 <span class="sr-only">Moving air icon</span>
-
-                <p><strong>Ventilation</strong> grading criteria:</p>
-
+                <h3 id="ventilation-grading-criteria-heading" class="card-title">
+                    <strong>Ventilation</strong> grading criteria:
+                </h3>
                 <ul>
                     <li>Robust Policy: Outdoors, or indoors with ventilation and air purification commensurate with capacity.</li>
                     <li>Efforts Made: Indoors with active air exchange with the outdoors.</li>
                     <li>No Policy: Indoors with no outdoor ventilation and no air purification.</li>
                 </ul>
             </div>
-        </div>
+        </section>
         
-        <div class="card" id="the-pledge">
+        <section class="card the-pledge" id="alternative-grading-criteria" aria-labelledby="alternative-grading-criteria-heading">
             <div class="card-body">
                 <span class="material-symbols-sharp floating-badge-icon" aria-hidden="true">alt_route</span>
                 <span class="sr-only">Alternative routes icon</span>
-
-                <p><strong>Alternatives</strong> grading criteria:</p>
-
+                <h3 id="alternative-grading-criteria-heading" class="card-title">
+                    <strong>Alternatives</strong> grading criteria:
+                </h3>
                 <ul>
                     <li>Robust Policy: Participants who exhibit symptoms or test positive during, or right before, the event have access to no questions asked refunds, exchanges, and remote participation options.</li>
                     <li>Efforts Made: Participants who exhibit symptoms or test positive during, or right before, the event have access to refunds, exchanges, or remote participation options.</li>
                     <li>No Policy: No refunds, exchanges, or remote participation options.</li>
                 </ul>
             </div>
-        </div>
+        </section>
 
     </main>
 

--- a/index.html
+++ b/index.html
@@ -4,9 +4,9 @@
     <meta charset="utf-8">
     <title>The Public Health Pledge, committing to safer and more inclusive events</title>
     <link rel="shortcut icon" href="img/favicon.png" type="image/png">
-    <link rel="stylesheet" href="main.css" type="text/css">
     <link rel="stylesheet" href="third_party/bootstrap/css/bootstrap.min.css">
     <link rel="stylesheet" href="third_party/fontawesome/css/all.min.css">
+    <link rel="stylesheet" href="main.css" type="text/css">
     <meta property="og:image" content="img/icon.png">
     <meta property="og:description" content="We are committing to safer and more inclusive events. You can too.">
     <meta property="og:title" content="The Public Health Pledge, committing to safer and more inclusive events">

--- a/main.css
+++ b/main.css
@@ -31,8 +31,11 @@ main {
         padding-left: 0.5em;
     }
 
-    #the-pledge {
+    .the-pledge {
         margin-bottom: 1em;
+    }
+    .the-pledge .card-title {
+        font-size: 1.125em;
     }
 
     #logos {


### PR DESCRIPTION
I have updated the heading outline for the event badging page and marked each of the cards as a region. This should help screenreader users navigate the page a little easier.

I have also moved the `main.css` after the third party libs. Since we are using `main.css` as our custom CSS styling, we should include that after the third party libraries, else our designs get overridden.

I have also updated the ids for the pledge card. `id` should be unique in a HTML page but all the cards had the same id.